### PR TITLE
Adjusts GDAL required version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["laurenssam <laurenssamson@hotmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.7,<3.11"
-GDAL = "3.4.3"
+GDAL = "^3.2"
 numpy = "1.21.6"
 Pillow = "9.1.0"
 scipy = "1.7.3"


### PR DESCRIPTION
Makes required version of GDAL package more lenient, compatible with some older code, and easier to work with. GDAL for Python must strictly match the version of the package installed on the operating system, or it will refuse to install.

Note for posterity: the lowest version of GDAL used in this repository was 3.2.2. It was then bumped to 3.4.3